### PR TITLE
[FIX] UNO 247 - Tooltips of 'Outcome Declarations' in Item properties starts with a letter of lowercase

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'QTI Portable Info Control',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '5.6.2',
+    'version' => '5.6.3',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'tao' => '>=23.0.0',

--- a/migrations/Version202009011223111298_qtiItemPic.php
+++ b/migrations/Version202009011223111298_qtiItemPic.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace oat\qtiItemPic\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\qtiItemPic\scripts\install\RegisterPicStudentToolSample;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
@@ -15,18 +17,18 @@ final class Version202009011223111298_qtiItemPic extends AbstractMigration
 
     public function getDescription(): string
     {
-        return '';
+        return 'Upgrade studentToolSample 0.4.2 -> 0.4.3';
     }
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
-
+        call_user_func(new RegisterPicStudentToolSample(), ['0.4.3']);
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
-
+        throw new IrreversibleMigration(
+            'In order to undo this migration, please revert the client-side changes and run ' . RegisterPicStudentToolSample::class
+        );
     }
 }

--- a/migrations/Version202009011223111298_qtiItemPic.php
+++ b/migrations/Version202009011223111298_qtiItemPic.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\qtiItemPic\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202009011223111298_qtiItemPic extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/views/js/picCreator/dev/studentToolSample/picCreator.json
+++ b/views/js/picCreator/dev/studentToolSample/picCreator.json
@@ -3,7 +3,7 @@
     "label": "Hint",
     "short": "Hint",
     "description": "Show a hint",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "author": "Sam Sipasseuth",
     "email": "sam@taotesting.com",
     "tags": [

--- a/views/js/picCreator/dev/studentToolSample/picCreator.json
+++ b/views/js/picCreator/dev/studentToolSample/picCreator.json
@@ -2,7 +2,7 @@
     "typeIdentifier": "studentToolSample",
     "label": "Hint",
     "short": "Hint",
-    "description": "show a hint",
+    "description": "Show a hint",
     "version": "0.4.2",
     "author": "Sam Sipasseuth",
     "email": "sam@taotesting.com",


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/UNO-247

**NOTE:** Test only in your `UDIR` environment, for other customers you will need to implement modifications

**Description**

There're several tooltips that start with lowercase letter in Item Authoring: 

**Steps to reproduce**

- Open an item in Authoring mode
- Hover the pointer over the question mark icon next to 'Hint' under 'Student tools' section in 'Item Properties' to call for a tooltip

**Actual result**

Tooltip starts with lower case letter: 'show a hint'

![image](https://user-images.githubusercontent.com/34692207/91736046-6aafd800-ebad-11ea-81e8-3fb9e381a1f6.png)

**Expected result**

Tooltip starts with capital letter: 'Show a hint'.
