### PR TITLE
[FIX] UNO-484 UNO-485 - Error IE11 don't support arrow functions in this repository

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'QTI Portable Info Control',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '5.6.3',
+    'version' => '5.6.4',
     'author' => 'Open Assessment Technologies',
     'requires' => array(
         'tao' => '>=23.0.0',

--- a/views/js/picManager/picManager.js
+++ b/views/js/picManager/picManager.js
@@ -87,7 +87,7 @@ define([
     function initStudentToolManager($container, $itemPanel, item) {
         var $placeholder;
         //get list of all info controls available
-        icRegistry.loadCreators().then(allInfoControls => {
+        icRegistry.loadCreators().then(function(allInfoControls) {
             //get item body container
             //editor panel..
             var $itemBody = $itemPanel.find('.qti-itemBody');
@@ -100,7 +100,7 @@ define([
                 $managerPanel,
                 i = 0;
 
-            _.each(allInfoControls, creator => {
+            _.each(allInfoControls, function(creator) {
                 var name = creator.getTypeIdentifier(),
                     manifest = icRegistry.get(name),
                     controlExists = _.indexOf(alreadySet, name) > -1,
@@ -178,7 +178,7 @@ define([
              * @returns {String[]}
              */
             function getOrderedPICNames() {
-                return _.keys(allInfoControls).reduce((ordered, infoContorolName) => {
+                return _.keys(allInfoControls).reduce(function(ordered, infoContorolName) {
                     if (infoContorolName === _studentToolbarId) {
                         ordered.unshift(infoContorolName);
                     } else {
@@ -194,7 +194,7 @@ define([
             function processAllControls() {
                 var cnt = 0;
 
-                _.forEach(getOrderedPICNames(), controlName => {
+                _.forEach(getOrderedPICNames(), function(controlName) {
                     const control = allInfoControls[controlName];
                     // is there any action required at all?
                     // if not and if there are still items


### PR DESCRIPTION
**Related to**

- https://oat-sa.atlassian.net/browse/UNO-484

- https://oat-sa.atlassian.net/browse/UNO-485

**Description**

Error in IE11 due to use ES6 arrow functions in a repository with no Babel support

**How to test**

- Open Item Authoring in IE11of any item
- No popup about error, no console errors